### PR TITLE
null `hasAny` and `hasAll` metadata before setting to avoid array merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# v0.1.3
+##### 2017-05-17
+- #1 [BUGFIX] `hasAny` and `hasAll` filters no longer merge their values, we null the key first

--- a/js/dataTables.improved-filters.js
+++ b/js/dataTables.improved-filters.js
@@ -232,7 +232,7 @@ ImprovedFilters._filterDate = function(data, checkVal, op) {
  * @type {string}
  * @static
  */
-ImprovedFilters.version = '0.1.2';
+ImprovedFilters.version = '0.1.3';
 
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -531,6 +531,8 @@ DataTable.Api.register('column().if.hasAll()', function () {
 
   // if we have parameters, set them
   // @todo: validate these values
+  // we clear our metadata first to ensure the values array does not merge
+  this.column(colIndex).meta.merge('_filters', { hasAll: null });
   this.column(colIndex).meta.merge('_filters', { hasAll: { values: values, splitBy: splitBy } });
   return this;
 });
@@ -570,6 +572,8 @@ DataTable.Api.register('column().if.hasAny()', function () {
 
   // if we have parameters, set them
   // @todo: validate these values
+  // we clear our metadata first to ensure the values array does not merge
+  this.column(colIndex).meta.merge('_filters', { hasAny: null });
   this.column(colIndex).meta.merge('_filters', { hasAny: { values: values, splitBy: splitBy } });
   return this;
 });


### PR DESCRIPTION
- previously, array filters were incorrectly merging the values array resulting in unexpected behavior
- added changelog file
- version bump to 0.1.3